### PR TITLE
docs: encourage subscribing to notifications over polling

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,17 +1,17 @@
 ---
 name: alby-bitcoin-builder
-description: Add bitcoin lightning wallet capabilities to your app using Nostr Wallet Connect (NIP-47), LNURL, and WebLN. Send and receive payments, handle payment notifications, fetch wallet balance and transaction list, do bitcoin to fiat currency conversions, query lightning addresses, conditionally settle payments (HOLD invoices), parse BOLT-11 invoices, verify payment preimages.
+description: Add bitcoin lightning wallet capabilities to your app using Nostr Wallet Connect (NIP-47), LNURL, and WebLN. Send and receive payments, subscribe to real-time payment notifications (use this instead of polling the transaction list), fetch wallet balance and transactions, do bitcoin to fiat currency conversions, query lightning addresses, conditionally settle payments (HOLD invoices), parse BOLT-11 invoices, verify payment preimages.
 license: Apache-2.0
 metadata:
   author: getAlby
-  version: "1.2.1"
+  version: "1.3.0"
 ---
 
 # Usage
 
 Use this skill to understand how to build apps that require bitcoin lightning wallet capabilities.
 
-- [NWC Client: Interact with a wallet to do things like sending and receive payments, listen to payment notifications, fetch balance and transaction list and wallet info](./references/nwc-client/nwc-client.md)
+- [NWC Client: Interact with a wallet to send and receive payments, subscribe to real-time payment notifications (preferred over polling), fetch balance, transaction list, and wallet info](./references/nwc-client/nwc-client.md)
 - [Lightning Tools: Request invoices from a lightning address, parse BOLT-11 invoices, verify a preimage for a BOLT-11 invoice, LNURL-Verify, do bitcoin <-> fiat conversions](./references/lightning-tools/lightning-tools.md)
 - [Bitcoin Connect: Browser-only UI components for connecting wallets and accepting payments in React, Vue, or pure HTML web apps](./references/bitcoin-connect/bitcoin-connect.md)
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: alby-bitcoin-builder
-description: Add bitcoin lightning wallet capabilities to your app using Nostr Wallet Connect (NIP-47), LNURL, and WebLN. Send and receive payments, subscribe to real-time payment notifications (use this instead of polling the transaction list), fetch wallet balance and transactions, do bitcoin to fiat currency conversions, query lightning addresses, conditionally settle payments (HOLD invoices), parse BOLT-11 invoices, verify payment preimages.
+description: Add bitcoin lightning wallet capabilities to your app using Nostr Wallet Connect (NIP-47), LNURL, and WebLN. Send and receive payments, subscribe to real-time payment notifications (use this instead of polling), fetch wallet balance and transactions, do bitcoin to fiat currency conversions, query lightning addresses, conditionally settle payments (HOLD invoices), parse BOLT-11 invoices, verify payment preimages.
 license: Apache-2.0
 metadata:
   author: getAlby

--- a/references/nwc-client/notifications.md
+++ b/references/nwc-client/notifications.md
@@ -1,12 +1,50 @@
-# Example
+# Notifications
 
-IMPORTANT: read the [typings](./nwc.d.ts) to better understand how this works.
+Subscribe to be notified in real time when a payment is sent or received by the wallet.
+
+**This is the correct way to react to wallet activity.** Do NOT poll `listTransactions` on a timer to detect new payments — it wastes bandwidth, adds latency, and hammers the relay and wallet service. A single `subscribeNotifications` call delivers `payment_received` and `payment_sent` events over the existing Nostr relay connection as soon as they happen.
+
+IMPORTANT: read the [typings](./nwc.d.ts) to better understand the `Nip47Notification` shape (notification types, transaction fields, amounts in millisats).
+
+## Basic usage
 
 ```ts
-const onNotification = (notification) =>
+const unsub = await client.subscribeNotifications((notification) => {
+  // notification.notification_type is "payment_received" or "payment_sent"
+  // notification.notification is a Nip47Transaction
   console.info("Got notification", notification);
+});
 
-const unsub = await client.subscribeNotifications(onNotification);
-
-// later you can call unsub(); if you don't need to subscribe any more
+// Later, when you no longer need the subscription:
+unsub();
 ```
+
+## Filtering by type
+
+```ts
+const unsub = await client.subscribeNotifications(
+  (notification) => {
+    const tx = notification.notification; // Nip47Transaction
+    console.info(`Received ${tx.amount / 1000} sats`, tx.description);
+    // e.g. update your UI, mark an order as paid, append to a transaction list, etc.
+  },
+  ["payment_received"], // only listen for incoming payments
+);
+```
+
+## Keeping a transaction list up to date
+
+If you're displaying a transaction list, fetch it ONCE with `listTransactions` on initial load, then use `subscribeNotifications` to prepend new entries as they arrive. Do NOT re-fetch `listTransactions` periodically.
+
+```ts
+let transactions = (await client.listTransactions({ limit: 50 })).transactions;
+
+const unsub = await client.subscribeNotifications((notification) => {
+  transactions = [notification.notification, ...transactions];
+  renderTransactions(transactions);
+});
+```
+
+## Cleanup
+
+Always call the returned `unsub()` when the subscription is no longer needed (component unmount, app shutdown, user logout) to close the relay subscription cleanly.

--- a/references/nwc-client/notifications.md
+++ b/references/nwc-client/notifications.md
@@ -2,7 +2,7 @@
 
 Subscribe to be notified in real time when a payment is sent or received by the wallet.
 
-**This is the correct way to react to wallet activity.** Do NOT poll `listTransactions` on a timer to detect new payments — it wastes bandwidth, adds latency, and hammers the relay and wallet service. A single `subscribeNotifications` call delivers `payment_received` and `payment_sent` events over the existing Nostr relay connection as soon as they happen.
+**This is the correct way to react to wallet activity.** Do NOT poll `listTransactions` or `lookupInvoice` on a timer to detect new payments or check whether an invoice has been paid — it wastes bandwidth, adds latency, and hammers the relay and wallet service. A single `subscribeNotifications` call delivers `payment_received` and `payment_sent` events over the existing Nostr relay connection as soon as they happen.
 
 IMPORTANT: read the [typings](./nwc.d.ts) to better understand the `Nip47Notification` shape (notification types, transaction fields, amounts in millisats).
 
@@ -43,6 +43,23 @@ const unsub = await client.subscribeNotifications((notification) => {
   transactions = [notification.notification, ...transactions];
   renderTransactions(transactions);
 });
+```
+
+## Waiting for a specific invoice to be paid
+
+Instead of polling `lookupInvoice` or `listTransactions`, subscribe to `payment_received` and match on `payment_hash`:
+
+```ts
+function waitForPayment(paymentHash: string): Promise<Nip47Transaction> {
+  return new Promise(async (resolve) => {
+    const unsub = await client.subscribeNotifications((notification) => {
+      if (notification.notification.payment_hash === paymentHash) {
+        unsub();
+        resolve(notification.notification);
+      }
+    }, ["payment_received"]);
+  });
+}
 ```
 
 ## Cleanup

--- a/references/nwc-client/nwc-client.md
+++ b/references/nwc-client/nwc-client.md
@@ -38,22 +38,14 @@ const client = new NWCClient({
 });
 ```
 
-## Reacting to wallet activity: subscribe, don't poll
+## Subscribe, don't poll
 
-To react to sent or received payments, **subscribe to notifications** with `client.subscribeNotifications(...)`. See [notifications](./notifications.md).
-
-Do NOT poll `client.listTransactions(...)` on a timer to detect new payments or to check whether a specific invoice has been paid. Polling wastes bandwidth, adds delay, and unnecessarily loads the relay and wallet service. The wallet pushes `payment_received` and `payment_sent` events to subscribers in real time over the existing relay connection.
-
-Typical patterns:
-
-- **Detect an incoming payment to your app** (e.g. invoice settled, order paid): subscribe to `payment_received` notifications and match on the transaction's `payment_hash`.
-- **Display a live transaction list**: fetch once with `listTransactions`, then prepend new transactions from notifications as they arrive.
-- **Wait for a specific invoice**: subscribe to `payment_received` and resolve when the matching `payment_hash` arrives, rather than polling `lookupInvoice` or `listTransactions`.
+To react to sent or received payments, **subscribe to notifications** rather than polling `listTransactions` or `lookupInvoice` on a timer. See [notifications](./notifications.md) for the patterns and the reasons why.
 
 ## Referenced files
 
 Make sure to read the [NWC Client typings](./nwc.d.ts) when using any of the below referenced files.
 
-- [Subscribe to notifications of sent or received payments (use this instead of polling)](./notifications.md)
+- [Subscribe to notifications of sent or received payments](./notifications.md)
 - [How to pay a BOLT-11 lightning invoice](pay-invoice.md)
 - [How to create, settle and cancel HOLD invoices for conditional payments](hold-invoices.md)

--- a/references/nwc-client/nwc-client.md
+++ b/references/nwc-client/nwc-client.md
@@ -38,10 +38,22 @@ const client = new NWCClient({
 });
 ```
 
+## Reacting to wallet activity: subscribe, don't poll
+
+To react to sent or received payments, **subscribe to notifications** with `client.subscribeNotifications(...)`. See [notifications](./notifications.md).
+
+Do NOT poll `client.listTransactions(...)` on a timer to detect new payments or to check whether a specific invoice has been paid. Polling wastes bandwidth, adds delay, and unnecessarily loads the relay and wallet service. The wallet pushes `payment_received` and `payment_sent` events to subscribers in real time over the existing relay connection.
+
+Typical patterns:
+
+- **Detect an incoming payment to your app** (e.g. invoice settled, order paid): subscribe to `payment_received` notifications and match on the transaction's `payment_hash`.
+- **Display a live transaction list**: fetch once with `listTransactions`, then prepend new transactions from notifications as they arrive.
+- **Wait for a specific invoice**: subscribe to `payment_received` and resolve when the matching `payment_hash` arrives, rather than polling `lookupInvoice` or `listTransactions`.
+
 ## Referenced files
 
 Make sure to read the [NWC Client typings](./nwc.d.ts) when using any of the below referenced files.
 
-- [subscribe to notifications of sent or received payments](./notifications.md)
+- [Subscribe to notifications of sent or received payments (use this instead of polling)](./notifications.md)
 - [How to pay a BOLT-11 lightning invoice](pay-invoice.md)
 - [How to create, settle and cancel HOLD invoices for conditional payments](hold-invoices.md)


### PR DESCRIPTION
## Summary
- Many builders poll `listTransactions` every few seconds to detect new payments — this wastes bandwidth, adds latency, and hammers the relay and wallet service.
- Add an explicit "subscribe, don't poll" section to [`references/nwc-client/nwc-client.md`](references/nwc-client/nwc-client.md) with concrete patterns: detecting incoming payments, keeping a live transaction list, waiting for a specific invoice.
- Expand [`references/nwc-client/notifications.md`](references/nwc-client/notifications.md) from a 6-line snippet into a proper guide (basic usage, filtering by type, fetch-once-then-subscribe pattern, cleanup).
- Surface notifications more prominently in the top-level [`SKILL.md`](SKILL.md) description and bump version to `1.3.0`.

## Test plan
- [ ] Review rendered Markdown on GitHub
- [x] Spot-check that an agent following the skill picks `subscribeNotifications` over polling `listTransactions` for "react to incoming payments" tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded guidance on real-time payment notifications with multiple usage examples.
  * Added clarification on best practices for monitoring wallet activity and transaction updates.
  * Included detailed patterns for subscribing to payment events and resource cleanup.
  * Updated usage details to emphasize subscription over polling and added info on balance, transactions, and wallet info retrieval.

* **Version Update**
  * Bumped to reflect enhancements in payment notification capabilities.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getAlby/builder-skill/pull/41)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getAlby/builder-skill/pull/41)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->