### PR TITLE
fix: add note about using dummy preimage for external payment

### DIFF
--- a/references/bitcoin-connect/bitcoin-connect.md
+++ b/references/bitcoin-connect/bitcoin-connect.md
@@ -89,6 +89,7 @@ const { setPaid } = launchPaymentModal({
 
 // For external payments (e.g. QR code scanned by another wallet):
 // setPaid({ preimage: "..." });
+// ONLY if you have no way to access the preimage, you can use setPaid({ preimage: "dummy" }); to ensure the payment modal shows the success screen and closes.
 ```
 
 ### Request WebLN provider

--- a/references/bitcoin-connect/bitcoin-connect.md
+++ b/references/bitcoin-connect/bitcoin-connect.md
@@ -89,7 +89,7 @@ const { setPaid } = launchPaymentModal({
 
 // For external payments (e.g. QR code scanned by another wallet):
 // setPaid({ preimage: "..." });
-// ONLY if you have no way to access the preimage, you can use setPaid({ preimage: "dummy" }); to ensure the payment modal shows the success screen and closes.
+// ONLY if you have no way to access the preimage (after verifying payment on your backend — see "External Wallets" section), you can use setPaid({ preimage: "dummy" }); to ensure the payment modal shows the success screen and closes.
 ```
 
 ### Request WebLN provider

--- a/references/bitcoin-connect/bitcoin-connect.md
+++ b/references/bitcoin-connect/bitcoin-connect.md
@@ -89,7 +89,7 @@ const { setPaid } = launchPaymentModal({
 
 // For external payments (e.g. QR code scanned by another wallet):
 // setPaid({ preimage: "..." });
-// ONLY if you have no way to access the preimage (after verifying payment on your backend — see "External Wallets" section), you can use setPaid({ preimage: "dummy" }); to ensure the payment modal shows the success screen and closes.
+// ONLY if you have no way to access the preimage (if your app has no backend, or after verifying payment on your backend — see "External Wallets" section), you can use setPaid({ preimage: "dummy" }); to ensure the payment modal shows the success screen and closes.
 ```
 
 ### Request WebLN provider

--- a/references/lightning-tools/lnurl.md
+++ b/references/lightning-tools/lnurl.md
@@ -18,3 +18,5 @@ NOTE: not all lightning address providers support LNURL-Verify.
 ```ts
 const isPaid = await invoice.isPaid();
 ```
+
+If `isPaid` is true, `invoice.preimage` should now be set.


### PR DESCRIPTION
In case where the app knows the payment was sent, but doesn't know the preimage

(Not sure if this is a good idea)

Specifically for LNURL-Verify the preimage will be set after verifyPayment (or isPaid which calls it internally).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced Bitcoin Connect payment modal documentation with guidance for handling cases where preimage data is unavailable.
  * Updated LNURL-Verify documentation to clarify preimage field requirements when payment verification succeeds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getAlby/builder-skill/pull/43?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->